### PR TITLE
add localeID & todayString for manage language

### DIFF
--- a/lib/src/header.dart
+++ b/lib/src/header.dart
@@ -1,29 +1,33 @@
 part of 'widget.dart';
 
 class Header extends StatelessWidget {
-  const Header({
-    Key? key,
-    required this.monthDate,
-    this.margin = const EdgeInsets.only(
-      left: 16.0,
-      right: 8.0,
-      top: 4.0,
-      bottom: 4.0,
-    ),
-    this.onPressed,
-    this.dateStyle,
-    this.todayStyle,
-  }) : super(key: key);
+  const Header(
+      {Key? key,
+      required this.monthDate,
+      this.margin = const EdgeInsets.only(
+        left: 16.0,
+        right: 8.0,
+        top: 4.0,
+        bottom: 4.0,
+      ),
+      this.onPressed,
+      this.dateStyle,
+      this.todayStyle,
+      this.todayString = 'Today',
+      this.localeID = "en"})
+      : super(key: key);
 
-  static final _dateFormatter = DateFormat().add_yMMMM();
+  final String localeID;
   final DateTime monthDate;
   final EdgeInsetsGeometry margin;
   final VoidCallback? onPressed;
   final TextStyle? dateStyle;
   final TextStyle? todayStyle;
+  final String todayString;
 
   @override
   Widget build(BuildContext context) {
+    final dateFormatter = DateFormat.yMMMM(localeID);
     final theme = Theme.of(context);
 
     return Container(
@@ -32,7 +36,7 @@ class Header extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           Text(
-            _dateFormatter.format(monthDate),
+            dateFormatter.format(monthDate),
             style: dateStyle ?? theme.textTheme.subtitle1!,
           ),
           InkWell(
@@ -46,7 +50,7 @@ class Header extends StatelessWidget {
                 vertical: 4.0,
               ),
               child: Text(
-                'Today',
+                todayString,
                 style: todayStyle ?? theme.textTheme.subtitle1!,
               ),
             ),

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -14,20 +14,26 @@ part 'week_view.dart';
 
 /// Advanced Calendar widget.
 class AdvancedCalendar extends StatefulWidget {
-  const AdvancedCalendar({
-    Key? key,
-    this.controller,
-    this.startWeekDay,
-    this.events,
-    this.weekLineHeight = 32.0,
-    this.preloadMonthViewAmount = 13,
-    this.preloadWeekViewAmount = 21,
-    this.weeksInMonthViewAmount = 6,
-    this.todayStyle,
-    this.dateStyle,
-    this.onHorizontalDrag,
-    this.innerDot = false,
-  }) : super(key: key);
+  const AdvancedCalendar(
+      {Key? key,
+      this.controller,
+      this.startWeekDay,
+      this.events,
+      this.weekLineHeight = 32.0,
+      this.preloadMonthViewAmount = 13,
+      this.preloadWeekViewAmount = 21,
+      this.weeksInMonthViewAmount = 6,
+      this.todayStyle,
+      this.dateStyle,
+      this.onHorizontalDrag,
+      this.innerDot = false,
+      this.localeID = "en",
+      this.todayString = 'Today'})
+      : super(key: key);
+
+  /// Settings to manage language [default : English]
+  final String localeID;
+  final String todayString;
 
   /// Calendar selection date controller.
   final AdvancedCalendarController? controller;
@@ -140,7 +146,11 @@ class _AdvancedCalendarState extends State<AdvancedCalendar>
         (index) => time.add(Duration(days: index * 1)),
       ).toList();
       _weekNames = List<String>.generate(7, (index) {
-        return DateFormat("EEEE").format(list[index]).split('').first;
+        return DateFormat.EEEE(widget.localeID)
+            .format(list[index])
+            .split('')
+            .first
+            .toUpperCase();
       });
     }
   }
@@ -181,6 +191,8 @@ class _AdvancedCalendarState extends State<AdvancedCalendar>
                       onPressed: _handleTodayPressed,
                       dateStyle: widget.dateStyle,
                       todayStyle: widget.todayStyle,
+                      localeID: widget.localeID,
+                      todayString: widget.todayString,
                     );
                   },
                 ),


### PR DESCRIPTION
Hello, a just added a localeID (used for `DateFormat`) and todayString to replace the original 'Today' by what ever we want (I didn't find an other solution for it).
#34